### PR TITLE
Fix main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rstacruz/startup-name-generator",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "lib/index.js",
   "license": "MIT",
   "dependencies": {
     "lodash": "4.17.4",


### PR DESCRIPTION
Looks like main is pointing to a file that doesn't exist, I'm getting "Cannot find module '@rstacruz/startup-name-generator'".