### PR TITLE
Add 'avi' prefix to constants.js

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,7 @@ const PREFIXES = [
   'active',
   'auto',
   'app',
+  'avi', // aviato
   'base', // basecamp
   'co',
   'con',


### PR DESCRIPTION
In honor of the (in)famous company from HBO's 'Silicon Valley'.